### PR TITLE
Fix your/you're typo

### DIFF
--- a/hug_website/app.py
+++ b/hug_website/app.py
@@ -129,7 +129,7 @@ def home():
                                       'validation and transformation. This leads to explicit and easy to follow '
                                       'endpoints.',
             'reuse_header': 'Write once. Use everywhere.',
-            'reuse_description': 'With hug your API and business logic is cleanly separated from the interface your '
+            'reuse_description': 'With hug your API and business logic is cleanly separated from the interface you\'re '
                                  'exposing it on, which means you can safely expose it over HTTP, CLI, and Python in '
                                  'one fell swoop.',
             'get_started_header': 'What are you waiting for?',

--- a/hug_website/views/latest.shpaml
+++ b/hug_website/views/latest.shpaml
@@ -14,7 +14,7 @@
             h1
                 Write once. Use everywhere.
             p
-                With hug 2.0.0 your API and business logic is cleanly separated from the interface your exposing it on, which means you can safely expose it over HTTP, CLI, and Python in one fell swoop.
+                With hug 2.0.0 your API and business logic is cleanly separated from the interface you're exposing it on, which means you can safely expose it over HTTP, CLI, and Python in one fell swoop.
             > script src=https://gist.github.com/timothycrosley/1669b902f00662e92216.js
 
     .seamless


### PR DESCRIPTION
I noticed a typo on the website relating to the common mistake of your/you're - http://www.grammar-monster.com/easily_confused/youre_your.htm

I noticed the applicable code is actually in two files, but I wasn't sure if one was generated by the other since there isn't much documentation.  As a result I manually modified both files.  Let me know if there's a preferred mechanism for generating one based on the other.